### PR TITLE
add record structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ of crEdnString: # ...
 of crEdnVector: # ...
 of crEdnList: # ...
 of crEdnMap: # ...
+of crEdnRecord: # ...
 
 formatToCirru(x) # returns string
 formatToCirru(x, true) # turn on useInline option
@@ -54,6 +55,7 @@ genCrEdnList(genCrEdn(1), genCrEdn(1))
 genCrEdnVector(genCrEdn(1), genCrEdn(1))
 genCrEdnSet(genCrEdn(1), genCrEdn(2))
 genCrEdnMap(genCrEdnKeyword("a"), genCrEdn(2)) # even number of arguments
+genCrEdnRecord("Demo", genCrEdn("a"), genCrEdn(2)) # odd number of arguments, string keys
 ```
 
 ### Syntax
@@ -76,6 +78,16 @@ list 1 2 3
 {}
   :a 1
   :b 3
+```
+
+- Record:
+
+Record name and record fields are represented in symbols:
+
+```cirru
+%{} Demo
+  a 1
+  b 2
 ```
 
 - Sets:

--- a/cirru_edn.nimble
+++ b/cirru_edn.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.4.5"
+version       = "0.4.6"
 author        = "jiyinyiyong"
 description   = "Cirru EDN loader in Nim"
 license       = "MIT"

--- a/cirru_edn.nimble
+++ b/cirru_edn.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.4.6"
+version       = "0.4.7"
 author        = "jiyinyiyong"
 description   = "Cirru EDN loader in Nim"
 license       = "MIT"

--- a/src/cirru_edn.nim
+++ b/src/cirru_edn.nim
@@ -4,6 +4,7 @@ import sequtils
 import tables
 import sets
 import options
+import algorithm
 
 import cirru_parser
 import cirru_writer
@@ -17,7 +18,7 @@ import cirru_edn/str_util
 export CirruEdnValue, CirruEdnKind, `$`, `==`, `!=`
 export EdnEmptyError, EdnInvalidError, EdnOpError
 export map, mapPairs, items, pairs, hash, get, contains, toJson, toCirruEdn
-export genCrEdn, genCrEdnKeyword, genCrEdnList, genCrEdnVector, genCrEdnSet, genCrEdnMap
+export genCrEdn, genCrEdnKeyword, genCrEdnList, genCrEdnVector, genCrEdnSet, genCrEdnMap, genCrEdnRecord
 
 proc mapExpr(tree: CirruNode): CirruEdnValue =
 
@@ -73,6 +74,37 @@ proc mapExpr(tree: CirruNode): CirruEdnValue =
           let v = mapExpr pair[1].get
           dict[k] = v
         return CirruEdnValue(kind: crEdnMap, mapVal: dict, line: tree.line, column: tree.column)
+      of "%{}":
+        var pairs: seq[RecordInPair]
+        let nameNode = tree[1].get()
+        if nameNode.kind != cirruToken:
+          raise newException(EdnInvalidError, "Expected a token")
+        for pair in tree[2..^1]:
+          if pair.kind == cirruToken:
+            echo $pair
+            raise newException(EdnInvalidError, "Must be pairs in a map")
+          if pair.len != 2:
+            echo $pair, " ", pair.len
+            raise newException(EdnInvalidError, "Must be pair of 2 in a map")
+          let kNode = pair[0].get
+          if kNode.kind != cirruToken:
+            echo kNode
+            raise newException(EdnInvalidError, "Expected a token")
+          let v = mapExpr pair[1].get
+          pairs.add((kNode.token, v))
+
+        pairs.sort(recordFieldOrder)
+
+        var fields: seq[string]
+        var values: seq[CirruEdnValue]
+        for pair in pairs:
+          fields.add pair.k
+          values.add pair.v
+        return CirruEdnValue(
+          kind: crEdnRecord, recordName: nameNode.token,
+          recordFields: fields, recordValues: values,
+        )
+
       of "quote":
         if tree.len != 2:
           raise newException(EdnInvalidError, "quote requires only 1 item")
@@ -104,6 +136,8 @@ proc parseCirruEdn*(code: string): CirruEdnValue =
         of "[]":
           return mapExpr(dataNode)
         of "{}":
+          return mapExpr(dataNode)
+        of "%{}":
           return mapExpr(dataNode)
         of "list":
           return mapExpr(dataNode)
@@ -165,9 +199,20 @@ proc transformToWriter(xs: CirruEdnValue): CirruWriterNode =
       var buffer = CirruWriterNode(kind: writerList, list: @[])
       buffer.list.add CirruWriterNode(kind: writerItem, item: "{}")
       for k, item in xs.mapVal:
-        var pair  = CirruWriterNode(kind: writerList, list: @[])
+        var pair = CirruWriterNode(kind: writerList, list: @[])
         pair.list.add(k.transformToWriter)
         pair.list.add(item.transformToWriter)
+        buffer.list.add pair
+      buffer
+
+    of crEdnRecord:
+      var buffer = CirruWriterNode(kind: writerList, list: @[])
+      buffer.list.add CirruWriterNode(kind: writerItem, item: "%{}")
+      buffer.list.add CirruWriterNode(kind: writerItem, item: xs.recordName)
+      for idx, field in xs.recordFields:
+        var pair = CirruWriterNode(kind: writerList, list: @[])
+        pair.list.add(CirruWriterNode(kind: writerItem, item: field))
+        pair.list.add(xs.recordValues[idx].transformToWriter)
         buffer.list.add pair
       buffer
 

--- a/src/cirru_edn.nim
+++ b/src/cirru_edn.nim
@@ -5,6 +5,7 @@ import tables
 import sets
 import options
 import algorithm
+import math
 
 import cirru_parser
 import cirru_writer
@@ -168,7 +169,9 @@ proc transformToWriter(xs: CirruEdnValue): CirruWriterNode =
     of crEdnBool:
       CirruWriterNode(kind: writerItem, item: $xs.boolVal)
     of crEdnNumber:
-      CirruWriterNode(kind: writerItem, item: $xs.numberVal)
+      let v = xs.numberVal
+      let n = if v.trunc == v: $(v.int) else: $v
+      CirruWriterNode(kind: writerItem, item: n)
     of crEdnString:
       let str = "|" & xs.stringVal
       CirruWriterNode(kind: writerItem, item: str)

--- a/src/cirru_edn/format.nim
+++ b/src/cirru_edn/format.nim
@@ -30,6 +30,18 @@ proc fromTableToString(children: Table[CirruEdnValue, CirruEdnValue]): string =
   tableStr = tableStr & "}"
   return tableStr
 
+proc formRecordToString(name: string, fields: seq[string], values: seq[CirruEdnValue]): string =
+  result = "%{" & name
+  if fields.len != values.len:
+    raise newException(EdnInvalidError, "Expected fields and values has same size")
+  for idx, field in fields:
+    if idx == 0:
+      result &= " "
+    else:
+      result &= ", "
+    result &= field & " " & toString(values[idx])
+  result &= "}"
+
 proc toString*(val: CirruEdnValue): string =
   case val.kind:
     of crEdnBool:
@@ -43,6 +55,7 @@ proc toString*(val: CirruEdnValue): string =
     of crEdnList: fromSeqToString(val.listVal)
     of crEdnSet: fromSetToString(val.setVal)
     of crEdnMap: fromTableToString(val.mapVal)
+    of crEdnRecord: formRecordToString(val.recordName, val.recordFields, val.recordValues)
     of crEdnNil: "nil"
     of crEdnKeyword: ":" & val.keywordVal
     of crEdnQuotedCirru: $(val.quotedVal)

--- a/src/cirru_edn/gen.nim
+++ b/src/cirru_edn/gen.nim
@@ -1,6 +1,7 @@
 
 import tables
 import sets
+import algorithm
 
 import ./types
 
@@ -45,3 +46,36 @@ proc genCrEdnMap*(xs: varargs[CirruEdnValue]): CirruEdnValue =
   for i in 0..<size:
     result.mapVal[xs[i * 2]] = xs[i * 2 + 1]
 
+proc genCrEdnRecord*(name: string, xs: varargs[CirruEdnValue]): CirruEdnValue =
+  if xs.len %% 2 != 0:
+    raise newException(ValueError, "Record generator expects even number of arguments")
+
+  let size = (xs.len / 2).int
+  result = CirruEdnValue(kind: crEdnMap, mapVal: initTable[CirruEdnValue, CirruEdnValue]())
+
+  var pairs: seq[RecordInPair]
+
+  for i in 0..<size:
+    var field: string
+    let fieldNode = xs[i * 2]
+
+    if fieldNode.kind == crEdnString:
+      field = fieldNode.stringVal
+    elif fieldNode.kind == crEdnKeyword:
+      field = fieldNode.stringVal
+    else:
+      raise newException(ValueError, "Expected primative values " & $fieldNode)
+    pairs.add((field, xs[i * 2 + 1]))
+
+  pairs.sort(recordFieldOrder)
+
+  var fields: seq[string]
+  var values: seq[CirruEdnValue]
+  for pair in pairs:
+    fields.add pair.k
+    values.add pair.v
+
+  return CirruEdnValue(
+    kind: crEdnRecord, recordName: name,
+    recordFields: fields, recordValues: values,
+  )

--- a/src/cirru_edn/util.nim
+++ b/src/cirru_edn/util.nim
@@ -87,6 +87,12 @@ proc toJson*(x: CirruEdnValue): JsonNode =
         raise newException(EdnOpError, "required string keys in JObject")
     return JsonNode(kind: JObject, fields: fields)
 
+  of crEdnRecord:
+    var fields: OrderedTable[string, JsonNode]
+    for idx, field in x.recordFields:
+      fields[field] = toJson(x.recordValues[idx])
+    return JsonNode(kind: JObject, fields: fields)
+
   of crEdnQuotedCirru:
     return toJson(x.quotedVal)
 

--- a/tests/test_edn.nim
+++ b/tests/test_edn.nim
@@ -56,6 +56,11 @@ test "parse set":
   check parseCirruEdn("set 1 :a") == genCrEdnSet(genCrEdn(1), genCrEdnKeyword("a"))
   check parseCirruEdn("#{} 1 :a") == genCrEdnSet(genCrEdn(1), genCrEdnKeyword("a"))
 
+test "parse record":
+  check parseCirruEdn("%{} Cat (color :red) (weight 100)") ==
+    genCrEdnRecord("Cat", genCrEdn("color"), genCrEdnKeyword("red"),
+                    genCrEdn("weight"), genCrEdn(100))
+
 test "iterable":
   let vectorData = parseCirruEdn("[] 1 2 3 4")
   var counted: int = 0
@@ -147,3 +152,22 @@ test "write":
   check parseCirruEdn(quotedExample).formatToCirru.strip == quotedExample.strip
 
   check formatToCirru(toCirruEdn(%*{"some chars:,$()\"aaa": "with |() a", "simple": "simple"})).strip == stringExample.strip
+
+let recordExample = """
+%{} Cat (color :red)
+  weight 100.0
+"""
+
+let recordExample2 = """
+%{} Cat (color :red)
+  owner $ %{} Person (:age 20.0)
+    :name |Chen
+  weight 100.0
+"""
+
+test "write record":
+  let c0 = genCrEdnRecord("Cat", genCrEdn("color"), genCrEdnKeyword("red"),
+                            genCrEdn("weight"), genCrEdn(100))
+  check formatToCirru(c0).strip == recordExample.strip
+
+  check formatToCirru(parseCirruEdn(recordExample2)).strip == recordExample2.strip

--- a/tests/test_edn.nim
+++ b/tests/test_edn.nim
@@ -119,15 +119,15 @@ test "quoted":
 let mixedExample = """
 {}
   |b $ {} (|c |d)
-  |a $ [] 1.0 2.0
+  |a $ [] 1 2
 """
 
 let arrayExample = """
-[] 1.0
-  [] 2.0
-    [] 3.0 ([] 4.0) 5.0
-    , 6.0
-  , 7.0
+[] 1
+  [] 2
+    [] 3 ([] 4) 5
+    , 6
+  , 7
 """
 
 let quotedExample = """
@@ -142,10 +142,10 @@ let stringExample = """
 
 test "write":
   check formatToCirru(toCirruEdn(%*{"a": [1.0, 2.0], "b": {"c": "d"}})).strip == mixedExample.strip
-  check formatToCirru(toCirruEdn(%*[1,2, "3", {}])).strip == "[] 1.0 2.0 |3 $ {}"
+  check formatToCirru(toCirruEdn(%*[1,2, "3", {}])).strip == "[] 1 2 |3 $ {}"
   check formatToCirru(toCirruEdn(%*[1, [2, [3, [4], 5], 6], 7])).strip == arrayExample.strip
   check formatToCirru(toCirruEdn(%* true)).strip == "do true"
-  check formatToCirru(toCirruEdn(%* 1)).strip == "do 1.0"
+  check formatToCirru(toCirruEdn(%* 1)).strip == "do 1"
   check formatToCirru(toCirruEdn(%* "a")).strip == "do |a"
   check formatToCirru(toCirruEdn(%* ":a")).strip == "do |:a"
 
@@ -155,14 +155,14 @@ test "write":
 
 let recordExample = """
 %{} Cat (color :red)
-  weight 100.0
+  weight 100
 """
 
 let recordExample2 = """
 %{} Cat (color :red)
-  owner $ %{} Person (:age 20.0)
+  owner $ %{} Person (:age 20)
     :name |Chen
-  weight 100.0
+  weight 100
 """
 
 test "write record":


### PR DESCRIPTION
A record may look like:

```cirru
%{} Cat
  color :red
  weight 100
```

where `Cat` `color` `weight` are all raw symbols since they are internally just raw stored as raw strings.

Notices that fields of a record are sorted in order for access performance.
