### PR TITLE
add support for symbol format

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Cirru EDN in Nim
 ### Usage
 
 ```nim
-requires "https://github.com/Cirru/cirru-edn.nim#v0.4.0"
+requires "https://github.com/Cirru/cirru-edn.nim#v0.4.8"
 ```
 
 ```nim
@@ -34,6 +34,7 @@ of crEdnBool: # ...
 of crEdnNumber: # ...
 of crEdnKeyword: # ...
 of crEdnString: # ...
+of crEdnSymbol: # ...
 of crEdnVector: # ...
 of crEdnList: # ...
 of crEdnMap: # ...
@@ -51,6 +52,7 @@ genCrEdn(true)
 genCrEdn(1)
 genCrEdn("a")
 genCrEdnKeyword("k")
+genCrEdnSymbol("s")
 genCrEdnList(genCrEdn(1), genCrEdn(1))
 genCrEdnVector(genCrEdn(1), genCrEdn(1))
 genCrEdnSet(genCrEdn(1), genCrEdn(2))
@@ -108,6 +110,10 @@ do :k
 
 ```cirru
 do nil
+```
+
+```cirru
+do 'sym
 ```
 
 - Strings, needs to be prefixed with a `|`(or a single escaped `"`):

--- a/cirru_edn.nimble
+++ b/cirru_edn.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.4.7"
+version       = "0.4.8"
 author        = "jiyinyiyong"
 description   = "Cirru EDN loader in Nim"
 license       = "MIT"

--- a/src/cirru_edn.nim
+++ b/src/cirru_edn.nim
@@ -19,7 +19,7 @@ import cirru_edn/str_util
 export CirruEdnValue, CirruEdnKind, `$`, `==`, `!=`
 export EdnEmptyError, EdnInvalidError, EdnOpError
 export map, mapPairs, items, pairs, hash, get, contains, toJson, toCirruEdn
-export genCrEdn, genCrEdnKeyword, genCrEdnList, genCrEdnVector, genCrEdnSet, genCrEdnMap, genCrEdnRecord
+export genCrEdn, genCrEdnKeyword, genCrEdnList, genCrEdnVector, genCrEdnSet, genCrEdnMap, genCrEdnRecord, genCrEdnSymbol
 
 proc mapExpr(tree: CirruNode): CirruEdnValue =
 
@@ -41,6 +41,8 @@ proc mapExpr(tree: CirruNode): CirruEdnValue =
         return CirruEdnValue(kind: crEdnString, stringVal: tree.token[1..tree.token.high], line: tree.line, column: tree.column)
       elif tree.token[0] == '"':
         return CirruEdnValue(kind: crEdnString, stringVal: tree.token[1..tree.token.high], line: tree.line, column: tree.column)
+      elif tree.token[0] == '\'':
+        return CirruEdnValue(kind: crEdnSymbol, symbolVal: tree.token[1..tree.token.high], line: tree.line, column: tree.column)
       elif tree.token.matchesFloat():
         return CirruEdnValue(kind: crEdnNumber, numberVal: parseFloat(tree.token), line: tree.line, column: tree.column)
       else:
@@ -174,6 +176,9 @@ proc transformToWriter(xs: CirruEdnValue): CirruWriterNode =
       CirruWriterNode(kind: writerItem, item: n)
     of crEdnString:
       let str = "|" & xs.stringVal
+      CirruWriterNode(kind: writerItem, item: str)
+    of crEdnSymbol:
+      let str = "'" & xs.symbolVal
       CirruWriterNode(kind: writerItem, item: str)
     of crEdnKeyword:
       CirruWriterNode(kind: writerItem, item: ":" & $xs.keywordVal)

--- a/src/cirru_edn/format.nim
+++ b/src/cirru_edn/format.nim
@@ -58,6 +58,7 @@ proc toString*(val: CirruEdnValue): string =
     of crEdnRecord: formRecordToString(val.recordName, val.recordFields, val.recordValues)
     of crEdnNil: "nil"
     of crEdnKeyword: ":" & val.keywordVal
+    of crEdnSymbol: "'" & val.keywordVal
     of crEdnQuotedCirru: $(val.quotedVal)
 
 proc `$`*(v: CirruEdnValue): string =

--- a/src/cirru_edn/gen.nim
+++ b/src/cirru_edn/gen.nim
@@ -14,11 +14,14 @@ proc genCrEdn*(x: float): CirruEdnValue =
 proc genCrEdn*(x: bool): CirruEdnValue =
   CirruEdnValue(kind: crEdnBool, boolVal: x)
 
-proc genCrEdn*(x: string, asKeyword: bool = false): CirruEdnValue =
+proc genCrEdn*(x: string): CirruEdnValue =
   CirruEdnValue(kind: crEdnString, stringVal: x)
 
-proc genCrEdnKeyword*(x: string, asKeyword: bool = false): CirruEdnValue =
+proc genCrEdnKeyword*(x: string): CirruEdnValue =
   CirruEdnValue(kind: crEdnKeyword, keywordVal: x)
+
+proc genCrEdnSymbol*(x: string): CirruEdnValue =
+  CirruEdnValue(kind: crEdnSymbol, symbolVal: x)
 
 proc genCrEdn*(): CirruEdnValue =
   CirruEdnValue(kind: crEdnNil)

--- a/src/cirru_edn/types.nim
+++ b/src/cirru_edn/types.nim
@@ -11,6 +11,7 @@ type
     crEdnBool,
     crEdnNumber,
     crEdnString,
+    crEdnSymbol,
     crEdnKeyword,
     crEdnVector,
     crEdnList,
@@ -27,6 +28,7 @@ type
     of crEdnBool: boolVal*: bool
     of crEdnNumber: numberVal*: float
     of crEdnString: stringVal*: string
+    of crEdnSymbol: symbolVal*: string
     of crEdnKeyword: keywordVal*: string
     of crEdnVector: vectorVal*: seq[CirruEdnValue]
     of crEdnList: listVal*: seq[CirruEdnValue]
@@ -58,6 +60,8 @@ proc hash*(value: CirruEdnValue): Hash =
       return hash("number:" & $value.numberVal)
     of crEdnString:
       return hash("string:" & value.stringVal)
+    of crEdnSymbol:
+      return hash("symbol:" & value.symbolVal)
     of crEdnNil:
       return hash("nil:")
     of crEdnBool:
@@ -114,6 +118,8 @@ proc `==`*(x, y: CirruEdnValue): bool =
       return x.boolVal == y.boolVal
     of crEdnString:
       return x.stringVal == y.stringVal
+    of crEdnSymbol:
+      return x.symbolVal == y.symbolVal
     of crEdnNumber:
       return x.numberVal == y.numberVal
     of crEdnKeyword:

--- a/src/cirru_edn/util.nim
+++ b/src/cirru_edn/util.nim
@@ -58,6 +58,8 @@ proc toJson*(x: CirruEdnValue): JsonNode =
     return JsonNode(kind: JFloat, fnum: x.numberVal)
   of crEdnString:
     return JsonNode(kind: JString, str: x.stringVal)
+  of crEdnSymbol:
+    return JsonNode(kind: JString, str: x.symbolVal)
   of crEdnKeyword:
     return JsonNode(kind: JString, str: x.keywordVal)
   of crEdnList:

--- a/tests/test_edn.nim
+++ b/tests/test_edn.nim
@@ -17,6 +17,7 @@ test "data gen":
   check genCrEdn(1) == CirruEdnValue(kind: crEdnNumber, numberVal: 1)
   check genCrEdn("a") == CirruEdnValue(kind: crEdnString, stringVal: "a")
   check genCrEdnKeyword("a") == CirruEdnValue(kind: crEdnKeyword, keywordVal: "a")
+  check genCrEdnSymbol("a") == CirruEdnValue(kind: crEdnSymbol, symbolVal: "a")
   check genCrEdnVector(genCrEdn(1)) == CirruEdnValue(kind: crEdnVector, vectorVal: @[ CirruEdnValue(kind: crEdnNumber, numberVal: 1) ])
   check genCrEdnVector(genCrEdnVector()) == CirruEdnValue(kind: crEdnVector, vectorVal: @[CirruEdnValue(kind: crEdnVector, vectorVal: @[])])
   check genCrEdnList(genCrEdn(1)) == CirruEdnValue(kind: crEdnList, listVal: @[ CirruEdnValue(kind: crEdnNumber, numberVal: 1) ])
@@ -34,6 +35,8 @@ test "parse literals":
   check parseCirruEdn("do |a") == genCrEdn("a")
   check parseCirruEdn("do \"\\\"a\"") == genCrEdn("a")
   check parseCirruEdn("do :k") == genCrEdnKeyword("k")
+
+  check parseCirruEdn("do 'a") == genCrEdnSymbol("a")
 
 test "parse vector":
   check parseCirruEdn("[]") == genCrEdnVector()
@@ -148,6 +151,7 @@ test "write":
   check formatToCirru(toCirruEdn(%* 1)).strip == "do 1"
   check formatToCirru(toCirruEdn(%* "a")).strip == "do |a"
   check formatToCirru(toCirruEdn(%* ":a")).strip == "do |:a"
+  check formatToCirru(genCrEdnList(CirruEdnValue(kind: crEdnSymbol, symbolVal: "a"))).strip == "list 'a"
 
   check parseCirruEdn(quotedExample).formatToCirru.strip == quotedExample.strip
 


### PR DESCRIPTION
`'a` is a symbol. not to use confused with internal structural symbol `a` in `%{} P (a |s)`, that is not using symbol syntax.
